### PR TITLE
CircleCI reports 36 CPU cores, but we are limited to 30

### DIFF
--- a/static-root-files/etc/bashrc
+++ b/static-root-files/etc/bashrc
@@ -1,0 +1,7 @@
+if [[ $(nproc) > 30 ]]; then
+  maxjobs=30
+else
+  maxjobs=auto
+fi
+
+echo "max-jobs = $maxjobs" >> /etc/nix/nix.conf

--- a/static-root-files/etc/nix/nix.conf
+++ b/static-root-files/etc/nix/nix.conf
@@ -1,1 +1,1 @@
-max-jobs = auto
+# max-jobs is set by /etc/bashrc to # of CPU cores or 30, whichever is lower


### PR DESCRIPTION
The error reported is `error: all build users are currently in use;
consider creating additional users and adding them to the 'nixbld' group`