### PR TITLE
Temporarily use a custom history file so that an old revision is built

### DIFF
--- a/scripts/image-update
+++ b/scripts/image-update
@@ -163,7 +163,7 @@ processEntry() {
 }
 
 
-curl -sSf "https://channels.nix.gsc.io/$channel/history-v2" \
+curl -sSf "https://gist.githubusercontent.com/zupo/8f8968c02dc35ffe835dbd78c430423d/raw/b068189a73bf0208854176714e8b6336adfaaf96/gistfile1.txt" \
   | tail -n"$count" \
   | tac \
   | while read -r entry; do


### PR DESCRIPTION
We need 7e9b0dff974c89e070da1ad85713ff3c20b0ca97 to be built for https://github.com/niteoweb/kai-app/pull/720