### PR TITLE
Keep using nix 2.3

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,6 +27,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v12
       with:
+        install_url: https://releases.nixos.org/nix/nix-2.3.15/install
         skip_adding_nixpkgs_channel: true
     - uses: cachix/cachix-action@v8
       with:


### PR DESCRIPTION
As of recently, Nix 2.4 was released that seems to break cachix's nix action.

```
/usr/bin/sh -c nix path-info --all | grep -v '.drv$' > /tmp/store-path-pre-build
error: experimental Nix feature 'nix-command' is disabled; use '--extra-experimental-features nix-command' to override
Error: Action failed with error: Error: The process '/usr/bin/sh' failed with exit code 1
```

Let's keep using Nix 2.3.x