### PR TITLE
Add automatic builds for nixos-22.05

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        channel: [ "nixos-21.11", "nixos-21.05", "nixos-20.09"]
+        channel: [ "nixos-22.05", "nixos-21.11", "nixos-21.05", "nixos-20.09"]
       fail-fast: false
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
nixpkgs version 22.05 has been released, let's start building containers with it.

Ref: https://github.com/NixOS/nixpkgs/releases/tag/22.05